### PR TITLE
feat: HealthKit 조회 분리 및 Client 위임 테스트 재작성

### DIFF
--- a/Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManager.swift
+++ b/Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManager.swift
@@ -126,9 +126,10 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
     /// 목록 노출에 필요한 최소 데이터(거리·시간·페이스·케이던스)만 추출한다.
     private func makeLightweightWorkout(from workout: HKWorkout) async -> HealthKitWorkout? {
         guard let distance = workout.totalDistance?.doubleValue(for: .meterUnit(with: .kilo)),
-              let averagePace = calculateAveragePace(from: workout),
-              let averageCadence = await fetchAverageCadence(for: workout)
+              let averagePace = calculateAveragePace(from: workout)
         else { return nil }
+
+        let averageCadence = await fetchAverageCadence(for: workout) ?? 0
 
         return HealthKitWorkout(
             distance: distance,
@@ -153,10 +154,10 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
     /// 일기 저장 시 필요한 전체 상세 데이터를 추출한다.
     private func makeDetailedWorkout(from workout: HKWorkout) async -> HealthKitWorkout? {
         guard let distance = workout.totalDistance?.doubleValue(for: .meterUnit(with: .kilo)),
-              let averagePace = calculateAveragePace(from: workout),
-              let averageCadence = await fetchAverageCadence(for: workout)
+              let averagePace = calculateAveragePace(from: workout)
         else { return nil }
 
+        let averageCadence = await fetchAverageCadence(for: workout) ?? 0
         let averageHeartRate = await fetchAverageHeartRate(for: workout) ?? 0
         let activeEnergyBurned = workout.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0
         let runningVerticalOscillation = await fetchAverageVerticalOscillation(for: workout) ?? 0

--- a/Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManager.swift
+++ b/Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManager.swift
@@ -58,7 +58,7 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
         return result
     }
 
-    // 단일 Date에 대한 피트니스 기록을 가져옵니다.
+    // 단일 Date에 대한 피트니스 기록을 가져옵니다. (목록 노출용 경량 데이터)
     public func fetchRunningData(for date: Date) async throws -> [HealthKitWorkout] {
         try await ensureAuthorizationIfNeeded()
 
@@ -68,15 +68,40 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
             return []
         }
 
-        let predicate = HKQuery.predicateForWorkouts(with: .running)
+        let workouts = try await queryWorkouts(start: startOfDay, end: endOfDay)
+
+        var results: [HealthKitWorkout] = []
+        for workout in workouts {
+            if let lightweight = await makeLightweightWorkout(from: workout) {
+                results.append(lightweight)
+            }
+        }
+        return results
+    }
+
+    // 특정 워크아웃(startDate ~ endDate)에 대한 전체 상세 데이터를 추출합니다. (일기 저장용)
+    public func fetchDetailedRunningData(from startDate: Date, to endDate: Date) async throws -> HealthKitWorkout? {
+        try await ensureAuthorizationIfNeeded()
+
+        let workouts = try await queryWorkouts(start: startDate, end: endDate)
+        guard let workout = workouts.first(where: { $0.startDate == startDate }) ?? workouts.first else {
+            return nil
+        }
+
+        return await makeDetailedWorkout(from: workout)
+    }
+
+    /// 러닝 워크아웃을 날짜 범위로 조회하는 공통 쿼리
+    private func queryWorkouts(start: Date, end: Date) async throws -> [HKWorkout] {
+        let runningPredicate = HKQuery.predicateForWorkouts(with: .running)
         let datePredicate = HKQuery.predicateForSamples(
-            withStart: startOfDay,
-            end: endOfDay,
+            withStart: start,
+            end: end,
             options: .strictStartDate
         )
-        let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [predicate, datePredicate])
+        let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [runningPredicate, datePredicate])
 
-        let workouts = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[HKWorkout], Error>) in
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[HKWorkout], Error>) in
             let query = HKSampleQuery(
                 sampleType: .workoutType(),
                 predicate: compoundPredicate,
@@ -96,47 +121,71 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
             }
             healthStore.execute(query)
         }
+    }
 
-        var results: [HealthKitWorkout] = []
-        for workout in workouts {
-            guard let distance = workout.totalDistance?.doubleValue(for: .meterUnit(with: .kilo)),
-                  let averagePace = calculateAveragePace(from: workout),
-                  let averageHeartRate = await fetchAverageHeartRate(for: workout),
-                  let averageCadence = await fetchAverageCadence(for: workout)
-            else { continue }
+    /// 목록 노출에 필요한 최소 데이터(거리·시간·페이스·케이던스)만 추출한다.
+    private func makeLightweightWorkout(from workout: HKWorkout) async -> HealthKitWorkout? {
+        guard let distance = workout.totalDistance?.doubleValue(for: .meterUnit(with: .kilo)),
+              let averagePace = calculateAveragePace(from: workout),
+              let averageCadence = await fetchAverageCadence(for: workout)
+        else { return nil }
 
-            let activeEnergyBurned = workout.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0
-            let runningVerticalOscillation = await fetchAverageVerticalOscillation(for: workout) ?? 0
-            let runningGroundContactTime = await fetchAverageGroundContactTime(for: workout) ?? 0
-            let walkingStepLength = await fetchAverageStepLength(for: workout) ?? 0
-            let restingHeartRate = await fetchAverageRestingHeartRate(for: workout) ?? 0
-            let runningPower = await fetchAverageRunningPower(for: workout) ?? 0
-            let runningStrideLength = await fetchAverageRunningStrideLength(for: workout) ?? 0
-            let heartRateRecoveryOneMinute = await fetchHeartRateRecoveryOneMinute(for: workout) ?? 0
+        return HealthKitWorkout(
+            distance: distance,
+            duration: workout.duration,
+            averagePace: averagePace,
+            averageHeartRate: 0,
+            averageCadence: averageCadence,
+            activeEnergyBurned: 0,
+            runningVerticalOscillation: 0,
+            runningGroundContactTime: 0,
+            walkingStepLength: 0,
+            restingHeartRate: 0,
+            runningPower: 0,
+            runningStrideLength: 0,
+            heartRateRecoveryOneMinute: 0,
+            routeData: nil,
+            startDate: workout.startDate,
+            endDate: workout.endDate
+        )
+    }
 
-            let routeData = try? await fetchRouteData(for: workout)
+    /// 일기 저장 시 필요한 전체 상세 데이터를 추출한다.
+    private func makeDetailedWorkout(from workout: HKWorkout) async -> HealthKitWorkout? {
+        guard let distance = workout.totalDistance?.doubleValue(for: .meterUnit(with: .kilo)),
+              let averagePace = calculateAveragePace(from: workout),
+              let averageCadence = await fetchAverageCadence(for: workout)
+        else { return nil }
 
-            let healthKitWorkout = HealthKitWorkout(
-                distance: distance,
-                duration: workout.duration,
-                averagePace: averagePace,
-                averageHeartRate: averageHeartRate,
-                averageCadence: averageCadence,
-                activeEnergyBurned: activeEnergyBurned,
-                runningVerticalOscillation: runningVerticalOscillation,
-                runningGroundContactTime: runningGroundContactTime,
-                walkingStepLength: walkingStepLength,
-                restingHeartRate: restingHeartRate,
-                runningPower: runningPower,
-                runningStrideLength: runningStrideLength,
-                heartRateRecoveryOneMinute: heartRateRecoveryOneMinute,
-                routeData: routeData,
-                startDate: workout.startDate,
-                endDate: workout.endDate
-            )
-            results.append(healthKitWorkout)
-        }
-        return results
+        let averageHeartRate = await fetchAverageHeartRate(for: workout) ?? 0
+        let activeEnergyBurned = workout.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0
+        let runningVerticalOscillation = await fetchAverageVerticalOscillation(for: workout) ?? 0
+        let runningGroundContactTime = await fetchAverageGroundContactTime(for: workout) ?? 0
+        let walkingStepLength = await fetchAverageStepLength(for: workout) ?? 0
+        let restingHeartRate = await fetchAverageRestingHeartRate(for: workout) ?? 0
+        let runningPower = await fetchAverageRunningPower(for: workout) ?? 0
+        let runningStrideLength = await fetchAverageRunningStrideLength(for: workout) ?? 0
+        let heartRateRecoveryOneMinute = await fetchHeartRateRecoveryOneMinute(for: workout) ?? 0
+        let routeData = try? await fetchRouteData(for: workout)
+
+        return HealthKitWorkout(
+            distance: distance,
+            duration: workout.duration,
+            averagePace: averagePace,
+            averageHeartRate: averageHeartRate,
+            averageCadence: averageCadence,
+            activeEnergyBurned: activeEnergyBurned,
+            runningVerticalOscillation: runningVerticalOscillation,
+            runningGroundContactTime: runningGroundContactTime,
+            walkingStepLength: walkingStepLength,
+            restingHeartRate: restingHeartRate,
+            runningPower: runningPower,
+            runningStrideLength: runningStrideLength,
+            heartRateRecoveryOneMinute: heartRateRecoveryOneMinute,
+            routeData: routeData,
+            startDate: workout.startDate,
+            endDate: workout.endDate
+        )
     }
 
     private func calculateAveragePace(from workout: HKWorkout) -> String? {
@@ -267,7 +316,46 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
         }
     }
 
-    private func fetchRouteData(for workout: HKWorkout) async throws -> Data? {
+    // startDate ~ endDate 기간에 대한 피트니스 기록을 가져옵니다.
+    public func fetchWeeklyRunningData(from startDate: Date, to endDate: Date) async throws -> [HealthKitWorkout] {
+        try await ensureAuthorizationIfNeeded()
+
+        let calendar = Calendar.current
+
+        // 시작일부터 종료일까지의 날짜 배열 생성
+        var dates: [Date] = []
+        var currentDate = calendar.startOfDay(for: startDate)
+        let normalizedEndDate = calendar.startOfDay(for: endDate)
+
+        while currentDate <= normalizedEndDate {
+            dates.append(currentDate)
+            guard let nextDate = calendar.date(byAdding: .day, value: 1, to: currentDate) else {
+                break
+            }
+            currentDate = nextDate
+        }
+
+        // 각 날짜에 대해 병렬로 데이터 조회
+        return await withTaskGroup(of: [HealthKitWorkout].self) { group in
+            for date in dates {
+                group.addTask { [self] in
+                    return (try? await self.fetchRunningData(for: date)) ?? []
+                }
+            }
+
+            // 결과를 하나의 배열로 합침
+            var results: [HealthKitWorkout] = []
+            for await result in group {
+                results.append(contentsOf: result)
+            }
+
+            return results
+        }
+    }
+}
+
+private extension HealthKitManager {
+    func fetchRouteData(for workout: HKWorkout) async throws -> Data? {
         let routeType = HKSeriesType.workoutRoute()
         let predicate = HKQuery.predicateForObjects(from: workout)
 
@@ -322,42 +410,5 @@ public final class HealthKitManager: HealthKitManagerProtocol, @unchecked Sendab
 
         // [Location]을 JSON Data로 인코딩
         return try? JSONEncoder().encode(locations)
-    }
-
-    // startDate ~ endDate 기간에 대한 피트니스 기록을 가져옵니다.
-    public func fetchWeeklyRunningData(from startDate: Date, to endDate: Date) async throws -> [HealthKitWorkout] {
-        try await ensureAuthorizationIfNeeded()
-
-        let calendar = Calendar.current
-
-        // 시작일부터 종료일까지의 날짜 배열 생성
-        var dates: [Date] = []
-        var currentDate = calendar.startOfDay(for: startDate)
-        let normalizedEndDate = calendar.startOfDay(for: endDate)
-
-        while currentDate <= normalizedEndDate {
-            dates.append(currentDate)
-            guard let nextDate = calendar.date(byAdding: .day, value: 1, to: currentDate) else {
-                break
-            }
-            currentDate = nextDate
-        }
-
-        // 각 날짜에 대해 병렬로 데이터 조회
-        return await withTaskGroup(of: [HealthKitWorkout].self) { group in
-            for date in dates {
-                group.addTask { [self] in
-                    return (try? await self.fetchRunningData(for: date)) ?? []
-                }
-            }
-
-            // 결과를 하나의 배열로 합침
-            var results: [HealthKitWorkout] = []
-            for await result in group {
-                results.append(contentsOf: result)
-            }
-
-            return results
-        }
     }
 }

--- a/Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManagerProtocol.swift
+++ b/Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManagerProtocol.swift
@@ -12,4 +12,5 @@ public protocol HealthKitManagerProtocol {
     func ensureAuthorizationIfNeeded() async throws
     func fetchRunningData(for date: Date) async throws -> [HealthKitWorkout]
     func fetchWeeklyRunningData(from startDate: Date, to endDate: Date) async throws -> [HealthKitWorkout]
+    func fetchDetailedRunningData(from startDate: Date, to endDate: Date) async throws -> HealthKitWorkout?
 }

--- a/RunDiary/Sources/Clients/HealthKitClient/HealthKitClient.swift
+++ b/RunDiary/Sources/Clients/HealthKitClient/HealthKitClient.swift
@@ -17,10 +17,12 @@ struct HealthKitClient {
 }
 
 extension HealthKitClient: DependencyKey {
-    static let liveValue: HealthKitClient = {
-        let manager = HealthKitManager()
+    static let liveValue: HealthKitClient = .live()
 
-        return HealthKitClient(
+    static func live(
+        manager: HealthKitManagerProtocol = HealthKitManager()
+    ) -> HealthKitClient {
+        HealthKitClient(
             fetchRunningDataBetweenDates: { startDate, endDate in
                 try await manager.fetchWeeklyRunningData(from: startDate, to: endDate)
             },
@@ -28,7 +30,7 @@ extension HealthKitClient: DependencyKey {
                 try await manager.fetchDetailedRunningData(from: startDate, to: endDate)
             }
         )
-    }()
+    }
 
     static let testValue = HealthKitClient(
         fetchRunningDataBetweenDates: unimplemented("\(Self.self).fetchRunningDataBetweenDates"),

--- a/RunDiary/Sources/Clients/HealthKitClient/HealthKitClient.swift
+++ b/RunDiary/Sources/Clients/HealthKitClient/HealthKitClient.swift
@@ -12,8 +12,8 @@ import Models
 
 @DependencyClient
 struct HealthKitClient {
-    var fetchRunningDataOnDate: @MainActor @Sendable (Date) async throws -> [HealthKitWorkout]
     var fetchRunningDataBetweenDates: @MainActor @Sendable (Date, Date) async throws -> [HealthKitWorkout]
+    var fetchDetailedRunningData: @MainActor @Sendable (Date, Date) async throws -> HealthKitWorkout?
 }
 
 extension HealthKitClient: DependencyKey {
@@ -21,44 +21,21 @@ extension HealthKitClient: DependencyKey {
         let manager = HealthKitManager()
 
         return HealthKitClient(
-            fetchRunningDataOnDate: { date in
-                try await manager.fetchRunningData(for: date)
-            },
             fetchRunningDataBetweenDates: { startDate, endDate in
                 try await manager.fetchWeeklyRunningData(from: startDate, to: endDate)
+            },
+            fetchDetailedRunningData: { startDate, endDate in
+                try await manager.fetchDetailedRunningData(from: startDate, to: endDate)
             }
         )
     }()
 
     static let testValue = HealthKitClient(
-        fetchRunningDataOnDate: unimplemented("\(Self.self).fetchRunningData"),
-        fetchRunningDataBetweenDates: unimplemented("\(Self.self).fetchWeeklyRunningData")
+        fetchRunningDataBetweenDates: unimplemented("\(Self.self).fetchRunningDataBetweenDates"),
+        fetchDetailedRunningData: unimplemented("\(Self.self).fetchDetailedRunningData")
     )
 
     static let previewValue = HealthKitClient(
-        fetchRunningDataOnDate: { _ in
-            // Mock 데이터 반환
-            [
-                HealthKitWorkout(
-                    distance: 5.2,
-                    duration: 3665,  // 1시간 1분 5초
-                    averagePace: "5'30\"",
-                    averageHeartRate: 155,
-                    averageCadence: 180,
-                    activeEnergyBurned: 450.0,
-                    runningVerticalOscillation: 8.2,
-                    runningGroundContactTime: 240.0,
-                    walkingStepLength: 1.1,
-                    restingHeartRate: 60.0,
-                    runningPower: 300.0,
-                    runningStrideLength: 1.1,
-                    heartRateRecoveryOneMinute: 20.0,
-                    routeData: nil,
-                    startDate: Calendar.current.date(byAdding: .second, value: -3665, to: .now)!,
-                    endDate: .now
-                ),
-            ]
-        },
         fetchRunningDataBetweenDates: { _, _ in
             // Mock 주간 데이터 반환 (7일)
             (0..<7).map { index in
@@ -83,6 +60,26 @@ extension HealthKitClient: DependencyKey {
                     endDate: .now
                 )
             }.compactMap { $0 }
+        },
+        fetchDetailedRunningData: { startDate, endDate in
+            HealthKitWorkout(
+                distance: 5.2,
+                duration: endDate.timeIntervalSince(startDate),
+                averagePace: "5'30\"",
+                averageHeartRate: 155,
+                averageCadence: 180,
+                activeEnergyBurned: 450.0,
+                runningVerticalOscillation: 8.2,
+                runningGroundContactTime: 240.0,
+                walkingStepLength: 1.1,
+                restingHeartRate: 60.0,
+                runningPower: 300.0,
+                runningStrideLength: 1.1,
+                heartRateRecoveryOneMinute: 20.0,
+                routeData: nil,
+                startDate: startDate,
+                endDate: endDate
+            )
         }
     )
 }

--- a/RunDiary/Sources/Clients/RunningRecordClient/RunningRecordClient.swift
+++ b/RunDiary/Sources/Clients/RunningRecordClient/RunningRecordClient.swift
@@ -24,6 +24,7 @@ extension RunningRecordClient: DependencyKey {
             @Dependency(\.persistencesClient) var persistencesClient
 
             // 1. Fetch (캐싱은 Repository가 담당, 권한은 Manager가 내부 처리)
+            //    목록 노출용 경량 데이터만 조회한다. 상세 지표는 일기 저장 시점에 추출된다.
             let healthKitWorkouts = try await healthKitClient.fetchRunningDataBetweenDates(
                 from.toDate(),
                 to.toDate()
@@ -33,22 +34,10 @@ extension RunningRecordClient: DependencyKey {
                 to.toDate()
             )
 
-            // 2. Migration: 새로운 HealthKit 필드가 nil인 기존 레코드 업데이트
-            let migrationOccurred = await Self.migrateHealthKitMetricsIfNeeded(
-                savedRecords: savedRecords,
-                healthKitWorkouts: healthKitWorkouts,
-                persistencesClient: persistencesClient
-            )
-
-            // 3. 마이그레이션 발생 시 다시 fetch (struct이므로 DB 변경이 반영되지 않음)
-            let finalRecords = migrationOccurred
-                ? try await persistencesClient.fetchRecords(from.toDate(), to.toDate())
-                : savedRecords
-
-            // 4. Build (비즈니스 로직은 Client가 담당)
+            // 2. Build (비즈니스 로직은 Client가 담당)
             return Self.merge(
                 healthKitWorkouts: healthKitWorkouts,
-                savedRecords: finalRecords,
+                savedRecords: savedRecords,
                 from: from,
                 to: to
             )
@@ -126,7 +115,7 @@ extension RunningRecordClient: DependencyKey {
 
             // 4. 중복 제거: SwiftData에 저장된 것은 HealthKit에서 제외
             let filteredHealthKit = healthKit.filter { workout in
-                !saved.contains(where: { $0.workout.startTime == workout.startTime })
+                !saved.contains { $0.workout.startTime == workout.startTime }
             }
 
             result[date] = DailyRecord(
@@ -150,49 +139,6 @@ extension RunningRecordClient: DependencyKey {
         }
 
         return dates
-    }
-
-    /// 새로 추가된 HealthKit 메트릭 필드가 nil인 기존 SwiftData 레코드를 HealthKit 데이터로 마이그레이션
-    /// - Returns: 마이그레이션이 발생했는지 여부
-    @MainActor
-    private static func migrateHealthKitMetricsIfNeeded(
-        savedRecords: [Diary],
-        healthKitWorkouts: [HealthKitWorkout],
-        persistencesClient: PersistencesClient
-    ) async -> Bool {
-        var migrationOccurred = false
-
-        for savedRecord in savedRecords {
-            // 마이그레이션이 필요한지 확인 (새 필드 중 하나라도 0이면)
-            let needsMigration = savedRecord.workout.activeEnergyBurned == 0
-                || savedRecord.workout.runningVerticalOscillation == 0
-                || savedRecord.workout.runningGroundContactTime == 0
-                || savedRecord.workout.walkingStepLength == 0
-
-            guard needsMigration else { continue }
-
-            // startTime으로 매칭되는 HealthKit workout 찾기
-            guard let matchingWorkout = healthKitWorkouts.first(where: { $0.startTime == savedRecord.workout.startTime }) else {
-                continue
-            }
-
-            // 마이그레이션 실행
-            do {
-                try await persistencesClient.updateRecord(
-                    recordId: savedRecord.id,
-                    activeEnergyBurned: matchingWorkout.activeEnergyBurned,
-                    runningVerticalOscillation: matchingWorkout.runningVerticalOscillation,
-                    runningGroundContactTime: matchingWorkout.runningGroundContactTime,
-                    walkingStepLength: matchingWorkout.walkingStepLength
-                )
-                migrationOccurred = true
-            } catch {
-                // 마이그레이션 실패는 무시하고 계속 진행 (데이터 fetch는 정상 동작해야 함)
-                AppLogger.app.warning("HealthKit 메트릭 마이그레이션 실패 - recordId: \(savedRecord.id), error: \(error.localizedDescription)")
-            }
-        }
-
-        return migrationOccurred
     }
 }
 

--- a/RunDiary/Sources/Features/CreateDiary/Core/CreateDiaryFeature.swift
+++ b/RunDiary/Sources/Features/CreateDiary/Core/CreateDiaryFeature.swift
@@ -95,6 +95,7 @@ struct CreateDiaryFeature {
 
     enum Action {
         case onAppear
+        case workoutDetailFetched(HealthKitWorkout?)
         case nextStepTapped
         case previousStepTapped
         case updateSelectedPainAreas(Set<PainArea>)
@@ -115,6 +116,7 @@ struct CreateDiaryFeature {
     }
 
     @Dependency(\.runningRecordClient) var runningRecordClient
+    @Dependency(\.healthKitClient) var healthKitClient
     @Dependency(\.weatherClient) var weatherClient
     @Dependency(\.shoeClient) var shoeClient
     @Dependency(\.dismiss) var dismiss
@@ -125,18 +127,35 @@ struct CreateDiaryFeature {
             case .onAppear:
                 let shoesEffect = loadShoesEffect(state: &state)
 
+                // 기존 기록 수정은 이미 전체 데이터를 보유하므로 상세 조회가 불필요하다.
                 if state.existingRecord != nil {
                     return shoesEffect
                 }
 
+                // 신규 기록은 목록에서 경량 데이터만 넘어오므로, 저장에 필요한 전체 상세를 여기서 추출한다.
                 let workout = state.healthKitWorkout
-                let location = extractLocationFromRoute(workout.routeData)
+                let detailEffect: Effect<Action> = .run { send in
+                    let detailed = try? await healthKitClient.fetchDetailedRunningData(
+                        workout.startTime,
+                        workout.endTime
+                    )
+                    await send(.workoutDetailFetched(detailed))
+                }
 
-                guard let location else { return shoesEffect }
+                return .merge(shoesEffect, detailEffect)
 
-                let middleTime = workoutMiddleTime(workout)
+            case let .workoutDetailFetched(detailed):
+                guard let detailed else { return .none }
 
-                let weatherEffect: Effect<Action> = .run { send in
+                state.healthKitWorkout = detailed
+
+                let location = extractLocationFromRoute(detailed.routeData)
+
+                guard let location else { return .none }
+
+                let middleTime = workoutMiddleTime(detailed)
+
+                return .run { send in
                     do {
                         let weather = try await weatherClient.fetchWeather(middleTime, location)
                         await send(.weatherFetched(weather))
@@ -145,8 +164,6 @@ struct CreateDiaryFeature {
                         await send(.weatherFetched(nil))
                     }
                 }
-
-                return .merge(shoesEffect, weatherEffect)
 
             case .nextStepTapped:
                 if let next = state.currentStep.next {

--- a/RunDiary/Sources/Features/CreateDiary/Core/CreateDiaryFeature.swift
+++ b/RunDiary/Sources/Features/CreateDiary/Core/CreateDiaryFeature.swift
@@ -135,11 +135,16 @@ struct CreateDiaryFeature {
                 // 신규 기록은 목록에서 경량 데이터만 넘어오므로, 저장에 필요한 전체 상세를 여기서 추출한다.
                 let workout = state.healthKitWorkout
                 let detailEffect: Effect<Action> = .run { send in
-                    let detailed = try? await healthKitClient.fetchDetailedRunningData(
-                        workout.startTime,
-                        workout.endTime
-                    )
-                    await send(.workoutDetailFetched(detailed))
+                    do {
+                        let detailed = try await healthKitClient.fetchDetailedRunningData(
+                            workout.startTime,
+                            workout.endTime
+                        )
+                        await send(.workoutDetailFetched(detailed))
+                    } catch {
+                        AppLogger.createDiary.error("상세 운동 데이터 조회 실패: \(error.localizedDescription)")
+                        await send(.workoutDetailFetched(nil))
+                    }
                 }
 
                 return .merge(shoesEffect, detailEffect)

--- a/RunDiary/Sources/Features/DailyDetail/Core/DailyDetailFeature.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Core/DailyDetailFeature.swift
@@ -154,37 +154,7 @@ struct DailyDetailFeature {
                 state.diaries = Dictionary(grouping: diaries, by: \.workout.yearMonthDay)
                 state.workouts = Dictionary(grouping: workouts, by: \.yearMonthDay)
                 state.isLoading = false
-                return .run { [persistencesClient] _ in
-                    // HealthKit -> SwiftData 데이터 동기화
-                    for diary in diaries {
-                        // 8개 속성 중 하나라도 0이면 마이그레이션 대상 (기존에는 nil 체크였으나 HealthKitWorkout에서는 0으로 처리됨)
-                        guard diary.workout.activeEnergyBurned == 0
-                            || diary.workout.runningVerticalOscillation == 0
-                            || diary.workout.runningGroundContactTime == 0
-                            || diary.workout.walkingStepLength == 0
-                            || diary.workout.restingHeartRate == 0
-                            || diary.workout.runningPower == 0
-                            || diary.workout.runningStrideLength == 0
-                            || diary.workout.heartRateRecoveryOneMinute == 0
-                        else { continue }
-
-                        // startTime이 일치하는 workout 찾기
-                        guard let matchingWorkout = workouts.first(where: { $0.startTime == diary.workout.startTime }) else { continue }
-
-                        // persistencesClient로 업데이트 요청
-                        try? await persistencesClient.updateRecord(
-                            recordId: diary.id,
-                            activeEnergyBurned: matchingWorkout.activeEnergyBurned,
-                            runningVerticalOscillation: matchingWorkout.runningVerticalOscillation,
-                            runningGroundContactTime: matchingWorkout.runningGroundContactTime,
-                            walkingStepLength: matchingWorkout.walkingStepLength,
-                            restingHeartRate: matchingWorkout.restingHeartRate,
-                            runningPower: matchingWorkout.runningPower,
-                            runningStrideLength: matchingWorkout.runningStrideLength,
-                            heartRateRecoveryOneMinute: matchingWorkout.heartRateRecoveryOneMinute
-                        )
-                    }
-                }
+                return .none
 
             case let .weekRecordsFetchFailed(error):
                 state.isLoading = false

--- a/RunDiary/Sources/Features/DailyDetail/Views/Components/HealthKitWorkoutCard.swift
+++ b/RunDiary/Sources/Features/DailyDetail/Views/Components/HealthKitWorkoutCard.swift
@@ -55,10 +55,6 @@ struct HealthKitWorkoutCard: View {
                     value: workout.averagePace
                 )
                 RecordVerticalRow(
-                    title: L10n.recordFieldHeartRate.value,
-                    value: "\(workout.averageHeartRate) \(L10n.unitBpm.value)"
-                )
-                RecordVerticalRow(
                     title: L10n.recordFieldCadence.value,
                     value: "\(workout.averageCadence) \(L10n.unitSpm.value)"
                 )
@@ -139,9 +135,8 @@ private struct PlaceholderItem: View {
                 routeData: nil,
                 startDate: Date(),
                 endDate: Date().addingTimeInterval(1935)
-            ),
-            onCreate: {}
-        )
+            )
+        ) {}
         .padding()
         Spacer()
     }

--- a/RunDiaryTests/CreateDiaryFeatureTests.swift
+++ b/RunDiaryTests/CreateDiaryFeatureTests.swift
@@ -332,7 +332,7 @@ struct CreateDiaryFeatureOnAppearTests {
         #expect(weatherFetchCalled == false)
     }
 
-    @Test("새 기록 + routeData 없음 → 신발만 로드")
+    @Test("새 기록 + 상세 데이터에 routeData 없음 → 신발만 로드")
     func onAppear_newRecordNoRoute_loadsOnlyShoes() async {
         let shoe = makeShoe(id: "s1")
         var weatherFetchCalled = false
@@ -343,6 +343,7 @@ struct CreateDiaryFeatureOnAppearTests {
             CreateDiaryFeature()
         } withDependencies: {
             $0.shoeClient.fetchAllShoes = { [shoe] }
+            $0.healthKitClient.fetchDetailedRunningData = { _, _ in makeWorkout() }
             $0.weatherClient.fetchWeather = { _, _ in
                 weatherFetchCalled = true
                 return WeatherData(temperature: 20, humidity: 50, windSpeed: 1)
@@ -353,18 +354,14 @@ struct CreateDiaryFeatureOnAppearTests {
             $0.dismiss = DismissEffect { }
         }
 
-        await store.send(.onAppear) {
-            $0.isShoesLoading = true
-        }
-        await store.receive(\.shoesLoaded) {
-            $0.isShoesLoading = false
-            $0.shoes = [shoe]
-        }
+        store.exhaustivity = .off
+        await store.send(.onAppear)
+        await store.skipReceivedActions()
 
         #expect(weatherFetchCalled == false)
     }
 
-    @Test("새 기록 + routeData 있음 → 날씨 조회 발생")
+    @Test("새 기록 + 상세 데이터에 routeData 있음 → 날씨 조회 발생")
     func onAppear_newRecordWithRoute_fetchesWeather() async {
         await ShoeCache.shared.reset()
         var weatherFetchCalled = false
@@ -373,14 +370,15 @@ struct CreateDiaryFeatureOnAppearTests {
             Location(latitude: 37.5, longitude: 127.0),
             Location(latitude: 37.6, longitude: 127.1)
         ])
-        let workout = makeWorkoutWithRoute(routeData: routeData)
+        let detailedWorkout = makeWorkoutWithRoute(routeData: routeData)
 
         let store = TestStore(
-            initialState: CreateDiaryFeature.State(healthKitWorkout: workout)
+            initialState: CreateDiaryFeature.State(healthKitWorkout: makeWorkout())
         ) {
             CreateDiaryFeature()
         } withDependencies: {
             $0.shoeClient.fetchAllShoes = { [] }
+            $0.healthKitClient.fetchDetailedRunningData = { _, _ in detailedWorkout }
             $0.weatherClient.fetchWeather = { _, _ in
                 weatherFetchCalled = true
                 return WeatherData(temperature: 20, humidity: 50, windSpeed: 1)

--- a/RunDiaryTests/DailyDetailFeatureTests.swift
+++ b/RunDiaryTests/DailyDetailFeatureTests.swift
@@ -684,54 +684,9 @@ struct DailyDetailFeatureTests {
         #expect(state.filteredWorkoutsOnSelectedDate == [w3])
     }
 
-    // MARK: - Migration Side-Effect Tests
+    // MARK: - Fetch Side-Effect Tests
 
-    @Test("weekRecordsFetched: metrics=0인 diary → HealthKit 데이터로 마이그레이션 호출")
-    func weekRecordsFetched_zeroMetricsDiary_triggersMigration() async {
-        // Given
-        let testDate = makeTodayYearMonthDay()
-        let weekDates = makeWeekDates(containing: testDate)
-        let startTime = testDate.toDate()
-
-        let diaryWithZeroMetrics = makeDiaryWithZeroMetrics(
-            yearMonthDay: testDate,
-            startTime: startTime
-        )
-        let matchingWorkout = makeHealthKitWorkout(
-            yearMonthDay: testDate,
-            startOffset: 0
-        )
-
-        var migratedRecordId: UUID?
-        var migratedActiveEnergy: Double?
-
-        var initialState = DailyDetailFeature.State(selectedDate: testDate)
-        initialState.dates = weekDates
-
-        let sut = TestStore(initialState: initialState) {
-            DailyDetailFeature()
-        } withDependencies: {
-            $0.persistencesClient.fetchRecords = { _, _ in [diaryWithZeroMetrics] }
-            $0.healthKitClient.fetchRunningDataBetweenDates = { _, _ in [matchingWorkout] }
-            $0.persistencesClient.update = { id, _, _, _, _, _, _, _, _, _, _, _, _, _, activeEnergy, _, _, _, _, _, _, _, _, _ in
-                migratedRecordId = id
-                migratedActiveEnergy = activeEnergy
-            }
-            $0.shoeClient.fetchAllShoes = { [] }
-        }
-
-        sut.exhaustivity = .off
-
-        // When
-        await sut.send(.fetchWeekRecords)
-        await sut.skipReceivedActions()
-
-        // Then
-        #expect(migratedRecordId == diaryWithZeroMetrics.id)
-        #expect(migratedActiveEnergy == matchingWorkout.activeEnergyBurned)
-    }
-
-    @Test("weekRecordsFetched: metrics 모두 0 초과인 diary → 마이그레이션 생략")
+    @Test("weekRecordsFetched: 조회 시 persistence 쓰기(update) 부작용 없음")
     func weekRecordsFetched_nonZeroMetrics_skipsMigration() async {
         // Given
         let testDate = makeTodayYearMonthDay()

--- a/RunDiaryTests/HealthKitClientTests.swift
+++ b/RunDiaryTests/HealthKitClientTests.swift
@@ -16,95 +16,6 @@ import Testing
 @Suite("HealthKitClient")
 struct HealthKitClientTests {
 
-  // MARK: - fetchRunningDataOnDate Tests
-
-  @Test("fetchRunningDataOnDate: 러닝 데이터 조회 성공")
-  func fetchRunningDataOnDateReturnsData() async throws {
-    let testDate = Date.now
-    let expectedData = [
-      HealthKitWorkout(
-        distance: 5.2,
-        duration: 1800,
-        averagePace: "5'30\"",
-        averageHeartRate: 155,
-        averageCadence: 180,
-        activeEnergyBurned: 450,
-        runningVerticalOscillation: 8.0,
-        runningGroundContactTime: 240.0,
-        walkingStepLength: 1.1,
-        restingHeartRate: 60.0,
-        runningPower: 300.0,
-        runningStrideLength: 1.1,
-        heartRateRecoveryOneMinute: 20.0,
-        routeData: nil,
-        startDate: testDate,
-        endDate: Calendar.current.date(byAdding: .second, value: 1800, to: testDate)!
-      ),
-      HealthKitWorkout(
-        distance: 3.5,
-        duration: 1200,
-        averagePace: "5'42\"",
-        averageHeartRate: 148,
-        averageCadence: 175,
-        activeEnergyBurned: 300,
-        runningVerticalOscillation: 8.2,
-        runningGroundContactTime: 250.0,
-        walkingStepLength: 1.0,
-        restingHeartRate: 55.0,
-        runningPower: 280.0,
-        runningStrideLength: 1.0,
-        heartRateRecoveryOneMinute: 22.0,
-        routeData: nil,
-        startDate: Calendar.current.date(byAdding: .hour, value: 3, to: testDate)!,
-        endDate: Calendar.current.date(byAdding: .hour, value: 3, to: testDate)!.addingTimeInterval(1200)
-      )
-    ]
-
-    let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in expectedData },
-      fetchRunningDataBetweenDates: { _, _ in [] }
-    )
-
-    let result = try await client.fetchRunningDataOnDate(testDate)
-
-    #expect(result.count == 2)
-    #expect(result[0].distance == 5.2)
-    #expect(result[0].duration == 1800)
-    #expect(result[0].averagePace == "5'30\"")
-    #expect(result[0].averageHeartRate == 155)
-    #expect(result[0].averageCadence == 180)
-    #expect(result[1].distance == 3.5)
-    #expect(result[1].duration == 1200)
-  }
-
-  @Test("fetchRunningDataOnDate: 데이터가 없을 때 빈 배열 반환")
-  func fetchRunningDataOnDateReturnsEmptyWhenNoData() async throws {
-    let testDate = Date.now
-
-    let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in [] },
-      fetchRunningDataBetweenDates: { _, _ in [] }
-    )
-
-    let result = try await client.fetchRunningDataOnDate(testDate)
-
-    #expect(result.isEmpty)
-  }
-
-  @Test("fetchRunningDataOnDate: 데이터 조회 중 에러 발생")
-  func fetchRunningDataOnDateThrowsError() async throws {
-    let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in
-        throw HealthKitError.notAvailable
-      },
-      fetchRunningDataBetweenDates: { _, _ in [] }
-    )
-
-    await #expect(throws: HealthKitError.self) {
-      try await client.fetchRunningDataOnDate(Date.now)
-    }
-  }
-
   // MARK: - fetchRunningDataBetweenDates Tests
 
   @Test("fetchRunningDataBetweenDates: 날짜 범위 러닝 데이터 조회 성공")
@@ -170,8 +81,8 @@ struct HealthKitClientTests {
     ]
 
     let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in [] },
-      fetchRunningDataBetweenDates: { _, _ in expectedData }
+      fetchRunningDataBetweenDates: { _, _ in expectedData },
+      fetchDetailedRunningData: { _, _ in nil }
     )
 
     let result = try await client.fetchRunningDataBetweenDates(startDate, endDate)
@@ -188,8 +99,8 @@ struct HealthKitClientTests {
     let endDate = Date.now
 
     let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in [] },
-      fetchRunningDataBetweenDates: { _, _ in [] }
+      fetchRunningDataBetweenDates: { _, _ in [] },
+      fetchDetailedRunningData: { _, _ in nil }
     )
 
     let result = try await client.fetchRunningDataBetweenDates(startDate, endDate)
@@ -203,10 +114,10 @@ struct HealthKitClientTests {
     let endDate = Date.now
 
     let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in [] },
       fetchRunningDataBetweenDates: { _, _ in
         throw HealthKitError.notAvailable
-      }
+      },
+      fetchDetailedRunningData: { _, _ in nil }
     )
 
     await #expect(throws: HealthKitError.self) {
@@ -220,8 +131,8 @@ struct HealthKitClientTests {
     let endDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
 
     let client = HealthKitClient(
-      fetchRunningDataOnDate: { _ in [] },
-      fetchRunningDataBetweenDates: { _, _ in [] }
+      fetchRunningDataBetweenDates: { _, _ in [] },
+      fetchDetailedRunningData: { _, _ in nil }
     )
 
     let result = try await client.fetchRunningDataBetweenDates(startDate, endDate)

--- a/RunDiaryTests/HealthKitClientTests.swift
+++ b/RunDiaryTests/HealthKitClientTests.swift
@@ -14,129 +14,248 @@ import Testing
 @testable import RunDiary
 
 @Suite("HealthKitClient")
+@MainActor
 struct HealthKitClientTests {
 
-  // MARK: - fetchRunningDataBetweenDates Tests
+    // MARK: - fetchRunningDataBetweenDates(weekly) Tests
 
-  @Test("fetchRunningDataBetweenDates: 날짜 범위 러닝 데이터 조회 성공")
-  func fetchRunningDataBetweenDatesReturnsData() async throws {
-    let startDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
-    let endDate = Date.now
+    @Test("weekly: 매니저가 반환한 데이터를 그대로 반환한다")
+    // TC: hkclient-weekly-returnsData
+    func fetchWeekly_returnsManagerData() async throws {
+        // Given
+        let expectedCount = 3
+        let expectedDistances: [Double] = [5.0, 7.5, 10.0]
+        let workouts = expectedDistances.map { makeHealthKitWorkout(distance: $0) }
+        let manager = StubHealthKitManager(weeklyResult: .success(workouts))
+        let client = makeSUT(manager: manager)
 
-    let expectedData = [
-      HealthKitWorkout(
-        distance: 5.0,
-        duration: 1800,
-        averagePace: "6'00\"",
-        averageHeartRate: 150,
-        averageCadence: 178,
-        activeEnergyBurned: 400,
-        runningVerticalOscillation: 8.0,
-        runningGroundContactTime: 240.0,
-        walkingStepLength: 1.0,
-        restingHeartRate: 58.0,
-        runningPower: 290.0,
-        runningStrideLength: 1.0,
-        heartRateRecoveryOneMinute: 21.0,
-        routeData: nil,
-        startDate: Calendar.current.date(byAdding: .day, value: -5, to: endDate)!,
-        endDate: Calendar.current.date(byAdding: .day, value: -5, to: endDate)!.addingTimeInterval(1800)
-      ),
-      HealthKitWorkout(
-        distance: 7.5,
-        duration: 2700,
-        averagePace: "6'00\"",
-        averageHeartRate: 160,
-        averageCadence: 182,
-        activeEnergyBurned: 600,
-        runningVerticalOscillation: 8.2,
-        runningGroundContactTime: 235.0,
-        walkingStepLength: 1.1,
-        restingHeartRate: 62.0,
-        runningPower: 310.0,
-        runningStrideLength: 1.1,
-        heartRateRecoveryOneMinute: 19.0,
-        routeData: nil,
-        startDate: Calendar.current.date(byAdding: .day, value: -3, to: endDate)!,
-        endDate: Calendar.current.date(byAdding: .day, value: -3, to: endDate)!.addingTimeInterval(2700)
-      ),
-      HealthKitWorkout(
-        distance: 10.0,
-        duration: 3600,
-        averagePace: "6'00\"",
-        averageHeartRate: 165,
-        averageCadence: 185,
-        activeEnergyBurned: 800,
-        runningVerticalOscillation: 8.5,
-        runningGroundContactTime: 230.0,
-        walkingStepLength: 1.2,
-        restingHeartRate: 65.0,
-        runningPower: 320.0,
-        runningStrideLength: 1.2,
-        heartRateRecoveryOneMinute: 18.0,
-        routeData: nil,
-        startDate: Calendar.current.date(byAdding: .day, value: -1, to: endDate)!,
-        endDate: Calendar.current.date(byAdding: .day, value: -1, to: endDate)!.addingTimeInterval(3600)
-      )
-    ]
+        // When
+        let result = try await client.fetchRunningDataBetweenDates(Date.now, Date.now)
 
-    let client = HealthKitClient(
-      fetchRunningDataBetweenDates: { _, _ in expectedData },
-      fetchDetailedRunningData: { _, _ in nil }
-    )
-
-    let result = try await client.fetchRunningDataBetweenDates(startDate, endDate)
-
-    #expect(result.count == 3)
-    #expect(result[0].distance == 5.0)
-    #expect(result[1].distance == 7.5)
-    #expect(result[2].distance == 10.0)
-  }
-
-  @Test("fetchRunningDataBetweenDates: 데이터가 없을 때 빈 배열 반환")
-  func fetchRunningDataBetweenDatesReturnsEmptyWhenNoData() async throws {
-    let startDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
-    let endDate = Date.now
-
-    let client = HealthKitClient(
-      fetchRunningDataBetweenDates: { _, _ in [] },
-      fetchDetailedRunningData: { _, _ in nil }
-    )
-
-    let result = try await client.fetchRunningDataBetweenDates(startDate, endDate)
-
-    #expect(result.isEmpty)
-  }
-
-  @Test("fetchRunningDataBetweenDates: 데이터 조회 중 에러 발생")
-  func fetchRunningDataBetweenDatesThrowsError() async throws {
-    let startDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
-    let endDate = Date.now
-
-    let client = HealthKitClient(
-      fetchRunningDataBetweenDates: { _, _ in
-        throw HealthKitError.notAvailable
-      },
-      fetchDetailedRunningData: { _, _ in nil }
-    )
-
-    await #expect(throws: HealthKitError.self) {
-      try await client.fetchRunningDataBetweenDates(startDate, endDate)
+        // Then
+        #expect(result.count == expectedCount)
+        #expect(result.map(\.distance) == expectedDistances)
     }
-  }
 
-  @Test("fetchRunningDataBetweenDates: 날짜 범위가 역순일 때")
-  func fetchRunningDataBetweenDatesWithReversedDates() async throws {
-    let startDate = Date.now
-    let endDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
+    @Test("weekly: 매니저가 빈 배열을 반환하면 빈 배열을 반환한다")
+    // TC: hkclient-weekly-empty
+    func fetchWeekly_returnsEmpty_whenManagerReturnsEmpty() async throws {
+        // Given
+        let manager = StubHealthKitManager(weeklyResult: .success([]))
+        let client = makeSUT(manager: manager)
 
-    let client = HealthKitClient(
-      fetchRunningDataBetweenDates: { _, _ in [] },
-      fetchDetailedRunningData: { _, _ in nil }
-    )
+        // When
+        let result = try await client.fetchRunningDataBetweenDates(Date.now, Date.now)
 
-    let result = try await client.fetchRunningDataBetweenDates(startDate, endDate)
+        // Then
+        #expect(result.isEmpty)
+    }
 
-    #expect(result.isEmpty)
-  }
+    @Test("weekly: 매니저가 에러를 던지면 동일한 에러를 재전파한다")
+    // TC: hkclient-weekly-throws
+    func fetchWeekly_throwsError_whenManagerThrows() async {
+        // Given
+        let manager = StubHealthKitManager(weeklyResult: .failure(HealthKitError.dataNotFound))
+        let client = makeSUT(manager: manager)
+
+        // When / Then
+        await #expect(throws: HealthKitError.dataNotFound) {
+            try await client.fetchRunningDataBetweenDates(Date.now, Date.now)
+        }
+    }
+
+    @Test("weekly: 전달받은 날짜(역순 포함)를 그대로 매니저에 전달한다")
+    // TC: hkclient-weekly-forwardsDates
+    func fetchWeekly_forwardsDates_toManager() async throws {
+        // Given
+        let startDate = Date.now
+        let endDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
+        let manager = StubHealthKitManager()
+        let client = makeSUT(manager: manager)
+
+        // When
+        _ = try await client.fetchRunningDataBetweenDates(startDate, endDate)
+
+        // Then
+        let capturedDates = manager.capturedWeeklyDates
+        #expect(capturedDates?.0 == startDate)
+        #expect(capturedDates?.1 == endDate)
+    }
+
+    @Test("weekly: fetchWeeklyRunningData만 호출하고 fetchDetailedRunningData는 호출하지 않는다")
+    // TC: hkclient-weekly-callsCorrectMethod
+    func fetchWeekly_callsOnlyWeeklyMethod() async throws {
+        // Given
+        let manager = StubHealthKitManager(
+            weeklyResult: .success([makeHealthKitWorkout(distance: 5.0)]),
+            detailedResult: .success(makeHealthKitWorkout(distance: 10.0))
+        )
+        let client = makeSUT(manager: manager)
+
+        // When
+        _ = try await client.fetchRunningDataBetweenDates(Date.now, Date.now)
+
+        // Then
+        #expect(manager.didCallWeekly == true)
+        #expect(manager.didCallDetailed == false)
+    }
+
+    // MARK: - fetchDetailedRunningData Tests
+
+    @Test("detailed: 매니저가 반환한 데이터를 그대로 반환한다")
+    // TC: hkclient-detailed-returnsData
+    func fetchDetailed_returnsManagerData() async throws {
+        // Given
+        let expectedWorkout = makeHealthKitWorkout(distance: 7.5)
+        let manager = StubHealthKitManager(detailedResult: .success(expectedWorkout))
+        let client = makeSUT(manager: manager)
+
+        // When
+        let result = try await client.fetchDetailedRunningData(Date.now, Date.now)
+
+        // Then
+        #expect(result == expectedWorkout)
+    }
+
+    @Test("detailed: 매니저가 nil을 반환하면 nil을 반환한다")
+    // TC: hkclient-detailed-returnsNil
+    func fetchDetailed_returnsNil_whenManagerReturnsNil() async throws {
+        // Given
+        let manager = StubHealthKitManager(detailedResult: .success(nil))
+        let client = makeSUT(manager: manager)
+
+        // When
+        let result = try await client.fetchDetailedRunningData(Date.now, Date.now)
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test("detailed: 매니저가 에러를 던지면 동일한 에러를 재전파한다")
+    // TC: hkclient-detailed-throws
+    func fetchDetailed_throwsError_whenManagerThrows() async {
+        // Given
+        let manager = StubHealthKitManager(detailedResult: .failure(HealthKitError.notAvailable))
+        let client = makeSUT(manager: manager)
+
+        // When / Then
+        await #expect(throws: HealthKitError.notAvailable) {
+            try await client.fetchDetailedRunningData(Date.now, Date.now)
+        }
+    }
+
+    @Test("detailed: 전달받은 날짜를 그대로 매니저에 전달한다")
+    // TC: hkclient-detailed-forwardsDates
+    func fetchDetailed_forwardsDates_toManager() async throws {
+        // Given
+        let startDate = Calendar.current.date(byAdding: .day, value: -7, to: Date.now)!
+        let endDate = Date.now
+        let manager = StubHealthKitManager()
+        let client = makeSUT(manager: manager)
+
+        // When
+        _ = try await client.fetchDetailedRunningData(startDate, endDate)
+
+        // Then
+        let capturedDates = manager.capturedDetailedDates
+        #expect(capturedDates?.0 == startDate)
+        #expect(capturedDates?.1 == endDate)
+    }
+
+    @Test("detailed: fetchDetailedRunningData만 호출하고 fetchWeeklyRunningData는 호출하지 않는다")
+    // TC: hkclient-detailed-callsCorrectMethod
+    func fetchDetailed_callsOnlyDetailedMethod() async throws {
+        // Given
+        let manager = StubHealthKitManager(
+            weeklyResult: .success([makeHealthKitWorkout(distance: 5.0)]),
+            detailedResult: .success(makeHealthKitWorkout(distance: 10.0))
+        )
+        let client = makeSUT(manager: manager)
+
+        // When
+        _ = try await client.fetchDetailedRunningData(Date.now, Date.now)
+
+        // Then
+        #expect(manager.didCallDetailed == true)
+        #expect(manager.didCallWeekly == false)
+    }
+}
+
+// MARK: - Test Helpers
+
+private extension HealthKitClientTests {
+    /// `HealthKitClient.live(manager:)`로 SUT를 생성한다.
+    /// 실제 `liveValue`와 동일한 배선(delegation) 로직을 태우기 위해
+    /// 고정 클로저 대신 `HealthKitClient.live`를 재사용한다.
+    func makeSUT(manager: StubHealthKitManager) -> HealthKitClient {
+        .live(manager: manager)
+    }
+
+    /// HealthKitWorkout 생성 헬퍼
+    func makeHealthKitWorkout(
+        distance: Double = 5.0,
+        startDate: Date = .now
+    ) -> HealthKitWorkout {
+        HealthKitWorkout(
+            distance: distance,
+            duration: 1800,
+            averagePace: "6'00\"",
+            averageHeartRate: 150,
+            averageCadence: 178,
+            activeEnergyBurned: 400,
+            runningVerticalOscillation: 8.0,
+            runningGroundContactTime: 240.0,
+            walkingStepLength: 1.0,
+            restingHeartRate: 58.0,
+            runningPower: 290.0,
+            runningStrideLength: 1.0,
+            heartRateRecoveryOneMinute: 21.0,
+            routeData: nil,
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(1800)
+        )
+    }
+}
+
+// MARK: - Stubs
+
+/// `fetchRunningDataBetweenDates`/`fetchDetailedRunningData`가 실제로 주입된 매니저에
+/// 위임하는지 검증하기 위한 테스트 전용 fake.
+private final class StubHealthKitManager: HealthKitManagerProtocol, @unchecked Sendable {
+    private let weeklyResult: Result<[HealthKitWorkout], Error>
+    private let detailedResult: Result<HealthKitWorkout?, Error>
+
+    var capturedWeeklyDates: (Date, Date)?
+    var capturedDetailedDates: (Date, Date)?
+    var didCallWeekly = false
+    var didCallDetailed = false
+
+    init(
+        weeklyResult: Result<[HealthKitWorkout], Error> = .success([]),
+        detailedResult: Result<HealthKitWorkout?, Error> = .success(nil)
+    ) {
+        self.weeklyResult = weeklyResult
+        self.detailedResult = detailedResult
+    }
+
+    func ensureAuthorizationIfNeeded() async throws {
+        Issue.record("unexpected call: ensureAuthorizationIfNeeded")
+    }
+
+    func fetchRunningData(for date: Date) async throws -> [HealthKitWorkout] {
+        Issue.record("unexpected call: fetchRunningData(for:)")
+        return []
+    }
+
+    func fetchWeeklyRunningData(from startDate: Date, to endDate: Date) async throws -> [HealthKitWorkout] {
+        didCallWeekly = true
+        capturedWeeklyDates = (startDate, endDate)
+        return try weeklyResult.get()
+    }
+
+    func fetchDetailedRunningData(from startDate: Date, to endDate: Date) async throws -> HealthKitWorkout? {
+        didCallDetailed = true
+        capturedDetailedDates = (startDate, endDate)
+        return try detailedResult.get()
+    }
 }

--- a/docs/specs/issue-29/tc-matrix.md
+++ b/docs/specs/issue-29/tc-matrix.md
@@ -1,0 +1,51 @@
+# TC 매트릭스 — HealthKitClient delegation
+
+> 이슈: #29
+> 대상 Client: `RunDiary/Sources/Clients/HealthKitClient/HealthKitClient.swift`
+> 대상 테스트: `RunDiaryTests/HealthKitClientTests.swift`
+> 주입 프로토콜: `Dependencies/HealthKitService/Sources/HealthKitService/HealthKitManagerProtocol.swift`
+
+## 배경
+
+`HealthKitClient`는 각 클로저가 대응 매니저 메서드로 위임하는 **순수 passthrough**다. 입력 검증/변환을 하지 않는다.
+기존 테스트는 하드코딩 클로저를 직접 주입해 "넣은 값이 그대로 나오는지"만 확인했다(무의미). 본 재작성은
+`HealthKitClient.live(manager:)` seam에 `StubHealthKitManager`를 주입해 **실제 배선(delegation)** 을 검증한다.
+
+Reducer가 아닌 Client이므로 UI/스냅샷(phase B/C)은 대상이 아니다.
+
+## Client-level TC (HealthKitClient)
+
+각 행 = given(StubHealthKitManager 구성) + when(Client 클로저 호출) → then(반환/에러/위임).
+
+| tc id | given (StubHealthKitManager) | when | then | 비고 |
+|---|---|---|---|---|
+| `hkclient-weekly-returnsData` | `weeklyResult=.success([w1,w2,w3])` | `fetchRunningDataBetweenDates(from,to)` | 동일 배열 반환(count==3, 각 값 일치) | 정상 위임 |
+| `hkclient-weekly-empty` | `weeklyResult=.success([])` | `fetchRunningDataBetweenDates(from,to)` | `[]` 반환 | 빈 결과 |
+| `hkclient-weekly-throws` | `weeklyResult=.failure(.dataNotFound)` | `fetchRunningDataBetweenDates(from,to)` | `HealthKitError.dataNotFound` 재전파 | 에러 전파 |
+| `hkclient-weekly-forwardsDates` | 인자 기록 stub, `from>to`(역순) | `fetchRunningDataBetweenDates(from,to)` | `capturedWeeklyDates == (from,to)` (역순도 검증 없이 전달) | 인자 전달 + 무검증 문서화 |
+| `hkclient-weekly-callsCorrectMethod` | weekly/detailed 서로 다른 값 | `fetchRunningDataBetweenDates(from,to)` | `didCallWeekly==true`, `didCallDetailed==false` | 교차 오호출 방지 |
+| `hkclient-detailed-returnsData` | `detailedResult=.success(w)` | `fetchDetailedRunningData(from,to)` | `w` 반환 | 정상 위임 |
+| `hkclient-detailed-returnsNil` | `detailedResult=.success(nil)` | `fetchDetailedRunningData(from,to)` | `nil` 반환 | 데이터 없음 |
+| `hkclient-detailed-throws` | `detailedResult=.failure(.notAvailable)` | `fetchDetailedRunningData(from,to)` | `HealthKitError.notAvailable` 재전파 | 에러 전파 |
+| `hkclient-detailed-forwardsDates` | 인자 기록 stub | `fetchDetailedRunningData(from,to)` | `capturedDetailedDates == (from,to)` | 인자 전달 |
+| `hkclient-detailed-callsCorrectMethod` | weekly/detailed 서로 다른 값 | `fetchDetailedRunningData(from,to)` | `didCallDetailed==true`, `didCallWeekly==false` | 교차 오호출 방지 |
+
+## 표준 커버리지 자가 점검
+- ✓ 액션별 정상 경로 (`returnsData` × 2)
+- ✓ 실패/에러 경로 (`throws` × 2, 서로 다른 에러 케이스)
+- ✓ 도메인 특수 분기 (`returnsNil`, `empty`)
+- ✓ 인자 전달 정확성 (`forwardsDates` × 2, 역순 포함)
+- ✓ 위임 대상 정확성 (`callsCorrectMethod` × 2)
+- ✓ 사용자 노출 에러 타입 정확성 (`HealthKitError` 재전파)
+
+## 명세-우선 재작성 흐름 (phase-a-reducer-respec.md)
+1. `HealthKitClientTests.swift` 기존 `@Test` **전체 주석화**(빌드 가능 유지).
+2. TC 하나씩: 작성 → 주석 해제 → `xcodebuild test` → 불일치(RED) 시 구현(seam) 수정, 명세 틀리면 이슈/TC 재검토 → GREEN.
+3. 반복.
+
+## 종료 조건
+- [ ] `HealthKitClient.live(manager:)` seam 도입, `liveValue = .live()`.
+- [ ] 위 TC 10건 전부 GREEN.
+- [ ] 주석 잔여 0 (기존 passthrough 테스트 모두 대체·삭제).
+- [ ] Swift strict concurrency 경고 0 (`SWIFT_STRICT_CONCURRENCY: complete`).
+- [ ] `healthKitClient` 소비처(`RunningRecordClient`/`DailyDetailFeature`/`CreateDiaryFeature`) 회귀 없음.


### PR DESCRIPTION
## 📝 작업 내용

#27에서 HealthKit 러닝 데이터 조회를 목록용 경량 조회와 일기 저장용 상세 조회로 분리했습니다.

해당 Client 구현은 당시 TDD 파이프라인보다 먼저 작성되었습니다. 이를 보완하기 위해 #29에서 이미 구현된 `HealthKitClient`의 실제 동작을 기준으로 delegation TC 10건을 명세하고, 하드코딩 클로저를 직접 검증하던 기존 passthrough 테스트를 실제 live 배선을 검증하는 테스트로 다시 작성했습니다.

## 🔨 구현 사항

- `HealthKitManager`의 목록용 경량 데이터 조회와 저장용 상세 데이터 조회를 분리하고 상세 지표를 일기 저장 시점에 지연 추출
- `HealthKitClient.live(manager:)` 주입 seam을 추가하고 `liveValue`가 동일한 live 팩토리를 사용하도록 정리
- `StubHealthKitManager`를 주입해 반환값·nil·에러 전파·날짜 전달·위임 대상 정확성을 검증하는 Client-level TC 10건 작성
- `docs/specs/issue-29/tc-matrix.md`에 구현된 Client 동작과 테스트 명세를 문서화

## ✅ 테스트

- [x] Unit Test 작성/수정
- [ ] 수동 테스트 완료
- [ ] SwiftUI Preview 동작 확인
- [ ] 테스트 불필요 (문서/설정 변경 등)

### 테스트 상세

- `xcodebuild test -project RunDiary.xcodeproj -scheme RunDiary -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' -only-testing:RunDiaryTests/HealthKitClientTests CODE_SIGNING_ALLOWED=NO`
- `HealthKitClientTests` 10건 전체 통과 (`TEST SUCCEEDED`)
- 테스트 실행 과정에서 앱 및 테스트 타깃 빌드 성공
- `git diff --check` 통과

## 📸 스크린샷

UI 변경 없음

## 🔗 관련 이슈

Closes #27
Closes #29

## 💬 리뷰어에게

#27 구현 이후 #29에서 테스트를 사후 보강한 작업입니다. 구현 전에 RED를 먼저 만든 형태는 아니지만, 현재 구현을 그대로 정답으로 복사하지 않고 Client의 공개 계약을 TC로 명세한 뒤 `HealthKitManagerProtocol` Stub을 통해 실제 `live(manager:)` 배선을 검증하도록 재작성했습니다.

주입 seam은 테스트 가능성을 위한 구조 변경이며 production 동작은 기존과 동일합니다.
